### PR TITLE
Parse links so they point to the appropriate place

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -27,7 +27,7 @@ def document(path=None):
     navigation = Navigation(drive)
 
     if not path:
-        document = navigation.hierarchy["home"]
+        document = navigation.hierarchy["index"]
     else:
         try:
             document = target_document(path, navigation.hierarchy)
@@ -36,7 +36,7 @@ def document(path=None):
             print(f"{err}\n {e}")
             flask.abort(404, description=err)
 
-    soup = Parser(drive, document["id"])
+    soup = Parser(drive, document["id"], navigation.object_dict)
 
     return flask.render_template(
         "index.html", navigation=navigation.hierarchy, html=soup.html

--- a/webapp/navigation.py
+++ b/webapp/navigation.py
@@ -5,10 +5,17 @@ class Navigation:
     def __init__(self, google_drive: Drive):
         file_list = google_drive.get_document_list()
         self.hierarchy = self.create_hierarchy(file_list)
+        self.object_dict
 
     def create_hierarchy(self, objects):
-        object_dict = {}
+        self.object_dict = {}
         root_objects = {}
+
+        def add_full_path(obj, path=""):
+            for key in obj.keys():
+                obj[key]["full_path"] = path + "/" + obj[key]["slug"]
+                if obj[key]["mimeType"] == "folder":
+                    add_full_path(obj[key]["children"], obj[key]["full_path"])
 
         for obj in objects:
             obj["children"] = {}
@@ -16,15 +23,18 @@ class Navigation:
             obj["slug"] = "-".join(obj["name"].split(" ")).lower()
             obj["active"] = False
             obj["expanded"] = False
-            object_dict[obj["id"]] = obj
+            obj["path"] = ""
+            self.object_dict[obj["id"]] = obj
 
         for obj in objects:
             parent_ids = obj["parents"]
             for parent_id in parent_ids:
-                parent_obj = object_dict.get(parent_id)
+                parent_obj = self.object_dict.get(parent_id)
                 if parent_obj is not None:
                     parent_obj["children"][obj["slug"]] = obj
                 else:
                     root_objects[obj["slug"]] = obj
 
-        return root_objects
+        add_full_path(root_objects)
+
+        return root_objects["library"]["children"]

--- a/webapp/parser.py
+++ b/webapp/parser.py
@@ -5,11 +5,13 @@ from webapp.googledrive import Drive
 
 
 class Parser:
-    def __init__(self, google_drive: Drive, document_id: str):
+    def __init__(self, google_drive: Drive, document_id: str, nav_dict):
         self.document_id = document_id
+        self.nav_dict = nav_dict
         raw_html = google_drive.get_html(document_id)
         self.html = BeautifulSoup(raw_html, features="html.parser")
         self.html = self.remove_attrs(self.html)
+        self.html = self.parse_links(self.html)
         self.parse_metadata()
 
     def remove_attrs(self, soup):
@@ -21,3 +23,16 @@ class Parser:
         table = self.html.select_one("table")
         if table:
             table.decompose()
+
+    def parse_links(self, soup):
+        external_path = "https://www.google.com/url?q="
+        google_doc_path = "docs.google.com/document/d/"
+        for a in soup.findAll("a", href=True):
+            if a["href"].startswith(external_path):
+                a["href"] = a["href"].replace(external_path, "")
+            if google_doc_path in a["href"]:
+                split_url = a["href"].split(google_doc_path)[1]
+                doc_id = split_url.split("/")[0]
+                if self.nav_dict.get(doc_id):
+                    a["href"] = self.nav_dict.get(doc_id)["full_path"]
+        return soup


### PR DESCRIPTION
## Done

- Creates `parse_links` function that finds all links of the page and if they are internal google documents updates the link to point internally (not to google drive)
- Create `add_full_path` function that traverses the 'hierarchy' dict and assign a `full_path` property to each obj

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8039/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-3193
