### PR TITLE
Add sticky footer styling for pages with short content

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-PORT=8039
+PORT=8051
 DEVEL=True
 FLASK_DEBUG=true
 SECRET_KEY=local_development_fake_key

--- a/templates/base_layout.html
+++ b/templates/base_layout.html
@@ -64,7 +64,7 @@
   <meta property="og:title" content="{% if title %}{{ title }} | Canonical Reference Library{% else %}Canonical Reference Library{% endif %}">
   <meta property="og:description" content="{% if description %}{{ description }}{% else %}Canonical Reference Library is single source of information for all corporate knowledge with Canonical{% endif %}">
 </head>
-<body>
+<body class="l-site">
   <!-- Google Tag Manager (noscript) -->
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TDV3PRK" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -1,4 +1,4 @@
-<footer class="p-strip--light">
+<footer class="l-footer--sticky p-strip--light">
   <div class="row">
     <p class="u-no-max-width">
         &copy; {{ now("%Y") }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical&nbsp;Ltd.


### PR DESCRIPTION
## Done

- Add Vanilla styling for [sticky footer](https://vanillaframework.io/docs/layouts/sticky-footer)
- Update the port and added it to our [documented ports list](https://discourse.canonical.com/t/default-ports-for-website-projects/142)

## QA

- Run this project with `dotrun` and ask for a key if you need it.
- Go to /canonical and see the footer is stuck to the footer