### PR TITLE
Allow hr tags through the parser

### DIFF
--- a/webapp/config/bs4_ignores.json
+++ b/webapp/config/bs4_ignores.json
@@ -1,5 +1,8 @@
 {
-  "font-weight:700": "strong",
-  "font-style:italic": "em",
-  "text-decoration:underline": "u"
+  "styles": {
+    "font-weight:700": "strong",
+    "font-style:italic": "em",
+    "text-decoration:underline": "u"
+  },
+  "tags": ["img", "hr"]
 }

--- a/webapp/parser.py
+++ b/webapp/parser.py
@@ -25,12 +25,12 @@ class Parser:
         for tag in soup.findAll(True):
             if tag.has_attr("style"):
                 tag_style = tag["style"]
-                for style, tag_name in bs4_ignores.items():
+                for style, tag_name in bs4_ignores["styles"].items():
                     if style in tag_style and not tag.find("a"):
                         tag.wrap(soup.new_tag(tag_name))
                 del tag["style"]
             del tag["id"]
-            if tag.name != "img" and len(tag.contents) == 0:
+            if tag.name not in bs4_ignores["tags"] and len(tag.contents) == 0:
                 tag.decompose()
         h1 = soup.select_one("h1")
         if not h1:


### PR DESCRIPTION
## Done

- Update bs4 _ignores.json to include a list of allowed empty tags (currently just `hr` and `img`)

## QA

- Run the project locally and see that hr tags are present

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-3543
