### PR TITLE
Fix memcached install issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ ENV LANG C.UTF-8
 WORKDIR /srv
 
 # Install memcached
-RUN apt-get update && apt-get install memcached
+RUN apt-get update && apt-get install -y memcached
 
 # Install python and import python dependencies
 RUN apt-get update && apt-get install --no-install-recommends --yes python3 python3-setuptools python3-lib2to3 python3-pkg-resources ca-certificates libsodium-dev


### PR DESCRIPTION
## Done

Added -y on the apt-get install memcached command

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8039/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
