### PR TITLE
Specify the target drive to pull documents from

### DIFF
--- a/.env
+++ b/.env
@@ -4,3 +4,4 @@ FLASK_DEBUG=true
 SECRET_KEY=local_development_fake_key
 OPENID_LAUNCHPAD_TEAM=canonical-content-people
 ROOT_FOLDER=library
+TARGET_DRIVE=0ABG0Z5eOlOvhUk9PVA

--- a/webapp/googledrive.py
+++ b/webapp/googledrive.py
@@ -1,4 +1,5 @@
 import io
+import os
 
 from flask import abort
 
@@ -10,6 +11,8 @@ from googleapiclient.discovery import build
 from google.oauth2 import service_account
 
 from webapp.settings import SERVICE_ACCOUNT_INFO
+
+TARGET_DRIVE = os.getenv("TARGET_DRIVE", "0ABG0Z5eOlOvhUk9PVA")
 
 cache = TTLCache(maxsize=100, ttl=1800)
 
@@ -34,9 +37,10 @@ class Drive:
                 self.service.files()
                 .list(
                     q="trashed=false",
-                    corpora="allDrives",
+                    corpora="teamDrive",
                     supportsTeamDrives=True,
                     includeItemsFromAllDrives=True,
+                    teamDriveId=TARGET_DRIVE,
                     spaces="drive",
                     fields="nextPageToken, "
                     "files(id, name, parents, mimeType)",
@@ -49,7 +53,6 @@ class Drive:
             abort(500, description=err)
 
         items = results.get("files", [])
-
         return items
 
     def fetch_document(self, document_id):


### PR DESCRIPTION
## Done

- Updates the `get_document_list` to only query the specified drive

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8051/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes the current 500

## Screenshots

[if relevant, include a screenshot]
