### PR TITLE
Make all folders require index files or they and their children wont be rendered

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -5,30 +5,25 @@
 Canonical Reference Library is single source of information for all corporate knowledge with Canonical
 {% endblock %}
 
-{% block meta_copydoc %}{% endblock %}
-
 {% block content %}
 {% macro create_navigation(nav_items, previous_slug, expandable=False, expanded=False) %}
   {% if nav_items %}
     <ul class="p-side-navigation__list" {% if expanded %}aria-expanded="true"{% endif %}>
       {% for element in nav_items %}
-        {% if (nav_items[element].mimeType == "document" and not nav_items[element].name|lower == "index") or (nav_items[element].children and nav_items[element].mimeType == "folder") %}
+        {% if (nav_items[element].mimeType == "document" and not nav_items[element].name|lower == "index") 
+        or (nav_items[element].children and nav_items[element]["children"]["index"]) %}
           <li class="p-side-navigation__item">
             {% if nav_items[element].mimeType == "document" or (nav_items[element]["children"]|length == 1 and nav_items[element]["children"]["index"]) %}
               <a
                 class="p-side-navigation__link {% if nav_items[element].children %}is-expandable{% endif %}" {% if nav_items[element].active %}aria-current="page"{% endif %}
                 href="/{{previous_slug}}/{{nav_items[element].slug}}"
               >{{ nav_items[element].name }}</a>
-            {% elif nav_items[element].children %}
-              {% if nav_items[element]["children"]["index"] %}
-                <a 
-                  class="p-side-navigation__link is-expandable u-no-margin--bottom" 
-                  href="/{{previous_slug}}/{{nav_items[element].slug}}" 
-                  {% if nav_items[element].active %}aria-current="page"{% endif %}
-                >{{ nav_items[element].name }}</a>
-              {% else %}
-                <em class="p-side-navigation__text is-expandable u-no-margin--bottom">{{ nav_items[element].name }}</em>
-              {% endif %}
+            {% elif nav_items[element].children and nav_items[element]["children"]["index"] %}
+              <a 
+                class="p-side-navigation__link is-expandable u-no-margin--bottom" 
+                href="/{{previous_slug}}/{{nav_items[element].slug}}" 
+                {% if nav_items[element].active %}aria-current="page"{% endif %}
+              >{{ nav_items[element].name }}</a>
               <button 
                 class="p-side-navigation__expand" 
                 {% if nav_items[element].expanded %}aria-expanded="true"{% endif %} 
@@ -60,7 +55,7 @@ Canonical Reference Library is single source of information for all corporate kn
         </div>
         <ul class="p-side-navigation__list">
           {% for nav_group in navigation %}
-            {% if (navigation[nav_group].name and not navigation[nav_group].name|lower == "index" and navigation[nav_group].children) 
+            {% if (navigation[nav_group].children and navigation[nav_group]["children"]["index"]) 
             or (navigation[nav_group].mimeType == "document" and not navigation[nav_group].name|lower == "index") %}
               <li class="p-side-navigation__item">
               {% if navigation[nav_group].mimeType == "document" %}
@@ -69,17 +64,12 @@ Canonical Reference Library is single source of information for all corporate kn
                   {% if navigation[nav_group].active %}aria-current="page"{% endif%}
                   href="/{{previous_slug}}/{{navigation[nav_group].slug}}"
                 >{{ navigation[nav_group].name }}</a>
-              {% elif navigation[nav_group].children and navigation[nav_group].mimeType == "folder" %}
-                {% if navigation[nav_group]["children"]["index"] %}
-                  <a 
-                    class="p-side-navigation__link is-expandable u-no-margin--bottom" 
-                    href="/{{navigation[nav_group].slug}}" 
-                    {% if navigation[nav_group].active %}aria-current="page"{% endif %}
-                  >{{ navigation[nav_group].name }}</a>
-                {% else %}
-                  <em class="p-side-navigation__text is-expandable u-no-margin--bottom"
-                  >{{ navigation[nav_group].name }}</em>
-                {% endif %}
+              {% elif navigation[nav_group].children and navigation[nav_group]["children"]["index"] %}
+                <a 
+                  class="p-side-navigation__link is-expandable u-no-margin--bottom" 
+                  href="/{{navigation[nav_group].slug}}" 
+                  {% if navigation[nav_group].active %}aria-current="page"{% endif %}
+                >{{ navigation[nav_group].name }}</a>
                 <button  
                   class="p-side-navigation__expand" 
                   {% if navigation[nav_group].expanded %}aria-expanded="true"{% endif %} 

--- a/webapp/navigation.py
+++ b/webapp/navigation.py
@@ -1,3 +1,5 @@
+import copy
+
 from webapp.googledrive import Drive
 
 
@@ -5,8 +7,10 @@ class Navigation:
     def __init__(self, google_drive: Drive, root_folder: str):
         self.root_folder = root_folder.lower()
         self.doc_reference_dict = {}
+        self.doc_hierarchy = {}
         file_list = google_drive.get_document_list()
-        self.hierarchy = self.create_hierarchy(file_list)
+        doc_objects_copy = copy.deepcopy(file_list)
+        self.hierarchy = self.create_hierarchy(doc_objects_copy)
 
     def add_path_context(self, hierarchy_obj, path="", breadcrumbs=None):
         if breadcrumbs is None:
@@ -34,7 +38,6 @@ class Navigation:
                 )
 
     def create_hierarchy(self, doc_objects):
-        doc_hierarchy = {}
         for doc in doc_objects:
             # If a document has now parent (shortcut) then we attach it
             # to the root folder
@@ -59,15 +62,15 @@ class Navigation:
                 if parent_obj is not None:
                     parent_obj["children"][doc["slug"]] = doc
                 elif doc["slug"] == self.root_folder:
-                    doc_hierarchy[doc["slug"]] = doc
+                    self.doc_hierarchy[doc["slug"]] = doc
                 elif doc["id"] in self.doc_reference_dict:
                     self.doc_reference_dict.pop(doc["id"])
 
         ordered_hierarchy = self.order_hierarchy(
-            doc_hierarchy[self.root_folder]["children"]
+            self.doc_hierarchy[self.root_folder]["children"]
         )
 
-        self.add_path_context(doc_hierarchy)
+        self.add_path_context(self.doc_hierarchy)
 
         return ordered_hierarchy
 


### PR DESCRIPTION
## Done

- Updates the template to require all folders to have an index file, this fixes a bug caused by side-navigation where it was looking for a child link that doesn't exist. This is also the long term intention of the Library, so will act to enforce this rule.
-  Makes a copy of the file passed to the create_hierarchy function, so when pre-numbers (ex. 10-) are removed it doesnt break the ordering

## QA

- Go to the demo and check that on load all the side nav is collapsed and that it is ordered based on the [drive document numbering](https://drive.google.com/drive/folders/1QLSNL1QhMMHJmDVFyTXoQ2V6RBtc8mjx)

