### PR TITLE
Update pr workflow secrets

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -48,29 +48,23 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install requirements
-        run: |
-          sudo apt-get update && sudo apt-get install --yes python3-setuptools
-          sudo pip3 install -r requirements.txt
-
-      - name: Install dotrun
-        uses: canonical/install-dotrun@main
-
-      - name: Install node dependencies
-        run: /snap/bin/dotrun install
-
-      - name: Install dependencies
-        run: /snap/bin/dotrun exec pip3 install coverage
-
-      - name: Build resources
-        run: /snap/bin/dotrun build
-      
-      - name: Create secrets file for dotrun
+      - name: Create secrets file 
         run:
           echo "${{ secrets.SECRETS_FILE }}" | base64 -d > .env.local
 
+      - name: Build image
+        run: DOCKER_BUILDKIT=1 docker build --tag library-canonical-com .
+
+      - name: Start container
+        run: |
+          docker run --env-file .env.local --network host --name lib-c-c -d library-canonical-com
+
+      - name: Install coverage
+        run: |
+          docker exec -i lib-c-c bash -c "apt-get update && apt-get install -y python3-pip && pip3 install coverage"
+      
       - name: Run tests with coverage
-        run: /snap/bin/dotrun exec coverage run --source=. -m unittest discover tests
+        run: docker exec -i lib-c-c coverage run --source=. -m unittest discover tests
 
   lint-python:
     runs-on: ubuntu-latest

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -22,7 +22,7 @@ class TestRoutes(unittest.TestCase):
         When given the index URL,
         we should return a 200 status code
         """
-        response = self.app.get('/')
+        response = self.app.get("/")
         self.assertEqual(response.status_code, 200)
 
     def test_not_found(self):
@@ -30,9 +30,9 @@ class TestRoutes(unittest.TestCase):
         When given a non-existent URL,
         we should return a 404 status code
         """
-        response = self.app.get('/not-found-url')
+        response = self.app.get("/not-found-url")
         self.assertEqual(response.status_code, 404)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -1,11 +1,18 @@
 import os
 
-PROJECT_ID = os.getenv("PROJECT_ID")
-PRIVATE_KEY_ID = os.getenv("PRIVATE_KEY_ID")
-PRIVATE_KEY = os.getenv("PRIVATE_KEY")
-CLIENT_EMAIL = os.getenv("CLIENT_EMAIL")
-CLIENT_ID = os.getenv("CLIENT_ID")
-CLIENT__X509_CERT_URL = os.getenv("CLIENT__X509_CERT_URL")
+
+def sanitize_env(env_var):
+    """Remove escape slashes and string environment variables"""
+    if env_var is not None:
+        return env_var.replace("\\n", "\n").replace('"', "")
+
+
+PROJECT_ID = sanitize_env(os.getenv("PROJECT_ID"))
+PRIVATE_KEY_ID = sanitize_env(os.getenv("PRIVATE_KEY_ID"))
+PRIVATE_KEY = sanitize_env(os.getenv("PRIVATE_KEY"))
+CLIENT_EMAIL = sanitize_env(os.getenv("CLIENT_EMAIL"))
+CLIENT_ID = sanitize_env(os.getenv("CLIENT_ID"))
+CLIENT__X509_CERT_URL = sanitize_env(os.getenv("CLIENT__X509_CERT_URL"))
 
 SERVICE_ACCOUNT_INFO = {
     "type": "service_account",


### PR DESCRIPTION
## Done

- Added secrets to github actions pr workflow as a **base64** encoded file
- Opted to run tests through a docker container instead of through dotrun. This is because dotrun doesn't run memcached on the local host.
- Installed coverage in the docker container and triggered the test suite from inside the container.

**Note**: The `SECRETS_FILE` secret is a **base64** encoded file in the `.env` style, with no leading `export` commands. Additional environment variables _can_ be added here, but care must be taken to re-encode the file before saving. 

## QA
- Confim that the ci checks and tests all run successfully


