### PR TITLE
Prepare for new theming of navigation

### DIFF
--- a/static/sass/_settings.scss
+++ b/static/sass/_settings.scss
@@ -3,7 +3,6 @@ $ubuntu-orange: #e95420;
 $mine-shaft: #333;
 $persian-red: #ce2d2d;
 $color-accent: $ubuntu-orange;
-$theme-default-nav: dark;
 $color-navigation-background: $mine-shaft;
 $color-navigation-active-bar: $ubuntu-orange;
 

--- a/templates/_partial/_navigation.html
+++ b/templates/_partial/_navigation.html
@@ -1,4 +1,4 @@
-<header id="navigation" class="p-navigation">
+<header id="navigation" class="p-navigation is-dark">
   <div class="l-full-width">
     <div class="l-start">
       <div class="p-navigation__banner u-no-padding--left">


### PR DESCRIPTION
## Done

Vanilla 4.10.0 is going to update top navigation to new theming and deprecates the use of `$theme-default-nav` variable.

This PR prepares for that by using `is-dark` class name on top nav.

## QA

- Check the demo: https://library-canonical-com-57.demos.haus/
- Make sure that top navigation displays as dark and has `is-dark` class name on `p-navigation` element


## Issue / Card

Related to: https://warthogs.atlassian.net/browse/WD-7594

