### PR TITLE
feat: Add fallback to navigation sorting function 'insert_based_on_position' to sort alphabetically if no 'position' value is present

### DIFF
--- a/webapp/navigation_builder.py
+++ b/webapp/navigation_builder.py
@@ -72,7 +72,7 @@ class NavigationBuilder:
 
             doc["children"] = {}
             doc["mimeType"] = doc["mimeType"].rpartition(".")[-1]
-            # Extract position information ('01-') and store it, 
+            # Extract position information ('01-') and store it,
             # since 'name' is edited.
             doc["position"] = extract_leading_number(doc["name"])
             doc["name"] = remove_leading_number(doc["name"])
@@ -121,7 +121,6 @@ class NavigationBuilder:
         item alphabetically after the ones with 'position' values.
         """
         slug = doc["slug"]
-        position = doc.get("position")
 
         # Add doc to children
         children = parent_obj["children"]
@@ -131,8 +130,12 @@ class NavigationBuilder:
         ordered_slugs = sorted(
             children.keys(),
             key=lambda s: (
-                children[s]["position"] if children[s]["position"] is not None else float("inf"),
-                s.lower()  # Sort alphabetically
+                (
+                    children[s]["position"]
+                    if children[s]["position"] is not None
+                    else float("inf")
+                ),
+                s.lower(),  # Sort alphabetically
             ),
         )
 


### PR DESCRIPTION
## Done

- Adds a an alphabetic sort as a secondary to the sorting Lamba in 'insert_based_on_position'
- Some changes to comments

## QA

- Go to [demo](https://library-canonical-com-71.demos.haus/)
- Check that the navigation matches the [drive](https://drive.google.com/drive/folders/1QLSNL1QhMMHJmDVFyTXoQ2V6RBtc8mjx)
- if you order by name in the drive it should look the same in the library (except in the drive folders always have priority over files)
![image](https://github.com/user-attachments/assets/c5a243ad-d7a0-498e-93c9-d49feff21c77)



## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-13525
