### PR TITLE
fix: make sure all index file are lowercase

### DIFF
--- a/webapp/navigation_builder.py
+++ b/webapp/navigation_builder.py
@@ -76,7 +76,7 @@ class NavigationBuilder:
             # since 'name' is edited.
             doc["position"] = extract_leading_number(doc["name"])
             temp_name = remove_leading_number(doc["name"])
-            if (temp_name == "Index"):
+            if temp_name == "Index":
                 temp_name = "index"
             doc["name"] = temp_name
             doc["slug"] = "-".join(doc["name"].split(" ")).lower()


### PR DESCRIPTION
## Done

Modify the naming in the navigation builder to make sure all index files are lowercase. Since some folders disappear if there is an file name Index.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8051/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
