### PR TITLE
fix: Direct the the links to documents not drive

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -59,7 +59,7 @@
             </p>
             {% if search_result.description %}<p>{{ search_result.description }}</p>
             {% else %}
-              <p>This document doesn't have description yet, you can add one to the metadata of the document: <a href="https://drive.google.com/drive/u/0/folders/{{TARGET_DRIVE}}/{{library_obj.id}}">https://drive.google.com/drive/u/0/folders/{{TARGET_DRIVE}}/{{library_obj.id}}</a></p>
+              <p>This document doesn't have description yet, you can add one to the metadata of the document: <a href="https://docs.google.com/document/d/{{library_obj.id}}">https://docs.google.com/document/d/{{library_obj.id}}</a></p>
             {% endif %}
             <a href="{{ library_obj.full_path }}">https://library.canonical.com{{ library_obj.full_path }}</a>
           </div>


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8051/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
