### PR TITLE
fix: solved display layout using column flex-flow

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -13,6 +13,10 @@ body p:not([class*="p-heading--"], [class*="p-muted-heading"]) + h1 {
   padding-top: 0.55rem;
 }
 
+body {
+  flex-flow: column;
+}
+
 // Sometimes the entire document is put in a table and it adds padding
 .l-docs__main > table > tbody > tr > td {
   padding: 0;


### PR DESCRIPTION
## Done

Solved the layout error while displaying the search results. 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8051/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
