### PR TITLE
Fix code blocks

### DIFF
--- a/webapp/parser.py
+++ b/webapp/parser.py
@@ -152,9 +152,7 @@ class Parser:
                         pre_tag.append(tag)
         # Clean up any unicode items that are left in the code blocks
         for tag in self.html.select("code:contains(\uec03)"):
-            tag.contents[0].replace_with(
-                tag.contents[0].replace("\uec03", "")
-            )
+            tag.contents[0].replace_with(tag.contents[0].replace("\uec03", ""))
             tag.contents[2].replace_with("")
         # Clean up empty p tags and clean unicode items in p tags
         for tag in self.html.findAll("p"):
@@ -190,9 +188,7 @@ class Parser:
             rows = table.find_all("tr")
             for row in rows:
                 columns = row.find_all("td")
-                key = (
-                    columns[0].get_text(strip=True).replace(" ", "_").lower()
-                )
+                key = columns[0].get_text(strip=True).replace(" ", "_").lower()
                 value = columns[1].get_text(strip=True)
                 self.metadata[key] = value
 


### PR DESCRIPTION
## Done
- Modify the way the parse wraps code block by implementing an start tag and end tag.
- start tag "\```code" and end tag "```endcode"
- implement some cleaning in the tag created, deleting empty tags and erasing any unicode items

## QA
To check the changes:
- Run the branch or check the Demo, to find code blocks examples navigate on the side navigation to the following
             Test and Issues -> Testing New Code Blocks 
- Check the code blocks render the in a single block form and not line by line (Check screenshots below)
 ---------------------

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8051/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots
Current Code Blocks rendering
![image](https://github.com/user-attachments/assets/c6ed6254-3193-4b4b-835f-c4dff8e76359)

New Code Block rendering
![image](https://github.com/user-attachments/assets/43b2a813-d196-4658-bec2-5d2a68b35591)

