### PR TITLE
fix: solve empty pages crashing

### DIFF
--- a/webapp/parser.py
+++ b/webapp/parser.py
@@ -310,7 +310,8 @@ class Parser:
                         )
                         tag["style"] = "color:inherit"
                         inner_tag = self.html.new_tag(
-                            "div", attrs={"class": "p-chip--caution u-no-margin"}
+                            "div",
+                            attrs={"class": "p-chip--caution u-no-margin"},
                         )
                         inner_tag.string = type
                         tag.append(inner_tag)


### PR DESCRIPTION
## Done

Modify the parse to identify if the body of the document is empty before adding items to it

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8051/
- Make sure all the features listed in the [Feature List](https://docs.google.com/document/d/1c7EWUyyz0X4x9G9cwrKjQ2GPfsk1-DrJv2fDYZLPgac/edit?tab=t.0) render correctly 
- Also check that empty page will render empty and don't show 500 error. You can find an example in about-the-library/test-and-issues/Empty-Document

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
