### PR TITLE
fix: clear caching for home page working now

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -235,14 +235,18 @@ def changes_drive():
     )
 
 
+@app.route("/clear-cache/")
 @app.route("/clear-cache/<path:path>")
-def clear_cache_doc(path):
+def clear_cache_doc(path=None):
     """
     Clear cache for a specific document
     """
     print("Clearing cache")
     print("PATH\n", path)
-    new_path = path.replace("/clear-cache", "")
+    if path is None:
+        new_path = ""
+    else:
+        new_path = path.replace("/clear-cache", "")
     cache_key = "view//%s" % new_path
 
     print("Cache Key", cache_key)
@@ -252,6 +256,8 @@ def clear_cache_doc(path):
         print(f"Cache for '{new_path}' not found.", 404)
     print("Redirecting to", new_path)
     return flask.redirect("/" + new_path)
+
+
 
 
 @app.route("/")


### PR DESCRIPTION
## Done

Modify the cache refresh so that it also work for the home screen

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8051/
- Try and use the refresh latest changes on the home page and it should get the latest changes, and not show a 404 error


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
