### PR TITLE
fix: add function to clean comments the rendering of documents

### DIFF
--- a/webapp/parser.py
+++ b/webapp/parser.py
@@ -39,7 +39,6 @@ class Parser:
         self.clean_comments()
         self.generate_headings_map()
         self.parse_create_doc_button()
-        
 
     def parse_nested_lists(self):
 


### PR DESCRIPTION
## Done

Added a method to make the comments in the documents not render in the library

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8051/
- Make sure library landing page shows no comments
- Make sure /documentation doesn't show comments
- Make sure /our-organisation/operations/project-management/devices-handbook/common-project-processes/initiation/set-up-project-infrastructure doesn't show any comments


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
