### PR TITLE
feat: delete WIP banner

### DIFF
--- a/templates/_partial/_footer.html
+++ b/templates/_partial/_footer.html
@@ -13,7 +13,7 @@
             <a href="" class="js-revoke-cookie-manager">Manage your tracker settings</a>
           </li>
           <li class="p-inline-list__item">
-              <a class="p-footer__link" href="https://warthogs.atlassian.net/jira/software/c/projects/LIB/form/100">Report a bug or feature suggestion</a>
+              <a class="p-footer__link" href="https://warthogs.atlassian.net/jira/software/c/projects/LIB/form/100">Report a bug or suggest a feature</a>
           </li>
           </ul>
           <span class="u-off-screen">


### PR DESCRIPTION
## Done

Delete the Work in progress Banner

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8051/
- Check the banner don't show anymore in any pages


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
