### PR TITLE
Update the parser to process both options of the version 3 metadata

### DIFF
--- a/webapp/parser.py
+++ b/webapp/parser.py
@@ -306,8 +306,8 @@ class Parser:
                                 .lower()
                             )
                             reviewers.append(key)
-                            if key == "reviewer(s)":
-                                self.metadata[key] = []
+                            if key == "reviewer(s)" or key == "reviewer":
+                                self.metadata["reviewer(s)"] = []
                     elif ind >= 8:
                         current_row = []
                         for icol in range(len(columns)):
@@ -316,10 +316,14 @@ class Parser:
                             current_row.append(value)
                         reviewer_dict = {}
                         for i in range(len(reviewers)):
-                            if reviewers[i] == "reviewer(s)":
+                            if (
+                                reviewers[i] == "reviewer(s)"
+                                or reviewers[i] == "reviewer"
+                            ):
                                 reviewer_dict["name"] = current_row[i]
                             else:
                                 reviewer_dict[reviewers[i]] = current_row[i]
+
                         self.metadata["reviewer(s)"].append(reviewer_dict)
             else:
                 # This works for metadata version 1 and 2


### PR DESCRIPTION
## Done

Update the parser to process both options of the version 3 metadata
- Identify that one of the table keys had change
- Update parser to be able to process both options

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8051/
- Check that /about-the-library/add-or-update-library-pages works correctly 
- Check that /about-the-library/tests-and-issues-(for-development-purpose)/metadata-table/metadata-table-v3 also works correctly


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
