### PR TITLE
feat: add all env as config options on the charm

### DIFF
--- a/charm/charmcraft.yaml
+++ b/charm/charmcraft.yaml
@@ -54,14 +54,20 @@ config:
       type: string
       default: "1cI2ClDWDzv3osp0Adn0w3Y7zJJ5h08ua"
     PRIVATE_KEY_ID:
-      type: secret
+      type: string
+      default: ""
     PRIVATE_KEY:
-      type: secret
+      type: string
+      default: ""
     PROJECT_ID:
-      type: secret
+      type: string
+      default: ""
     CLIENT_EMAIL:
-      type: secret
+      type: string
+      default: ""
     CLIENT_ID:
-      type: secret
+      type: string
+      default: ""
     CLIENT_X509_CERT_URL:
-      type: secret
+      type: string
+      default: ""


### PR DESCRIPTION
## Done

Modify the charmcraft file to manage the env variables
Nothing on current deployment should be affected

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8051/


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
