### PR TITLE
add prints to track error in spreadsheet method

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -33,6 +33,7 @@ DRAFTS_URL = (
     "https://drive.google.com/drive/folders/1cI2ClDWDzv3osp0Adn0w3Y7zJJ5h08ua"
 )
 
+print("URL_DOC", URL_DOC, flush=True)
 
 app = FlaskBase(
     __name__,

--- a/webapp/googledrive.py
+++ b/webapp/googledrive.py
@@ -227,6 +227,7 @@ class GoogleDrive:
             abort(500, description=error)
 
     def fetch_spreadsheet(self, document_id):
+        print("Fetching spreadsheet", document_id, flush=True)
         try:
 
             request = self.service.files().export(
@@ -237,9 +238,11 @@ class GoogleDrive:
             downloader = MediaIoBaseDownload(file, request)
             done = False
             while done is False:
+                print("Downloading chunk...", flush=True)
                 _, done = downloader.next_chunk()
             csv = file.getvalue().decode("utf-8")
-
+            print("Download complete", flush=True)
+            print("CSV content:", csv[:100], flush=True)  # Log first 100 chars
             if csv:
                 return csv
             else:


### PR DESCRIPTION
## Done

Add prints to the spreadsheet method, try to pinpoint what is causing the charm to get error 500

## QA

- Check out this feature branch
- Run the site using the command ./run serve
- View the site locally in your web browser at: http://0.0.0.0:8051/
- Please Check the following basic functionalities work correctly:
   - Library displays docs correctly
   - Library search works correctly and display list of results
   - Library displays code correctly -> Check /about-the-library/tests-and-issues-(for-development-purpose)/code-formatting
   - Library displays list and tables correctly ->/about-the-library/tests-and-issues-(for-development-purpose)/table-and-list-examples
   - Library soft roots work correctly


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
