### PR TITLE
Updating deploy.yaml to deploy fresh to new model

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -221,5 +221,5 @@ jobs:
           ls -la
           # run the deploy command
           # in a fresh environment first
-          # juju deploy ./library-charm_amd64.charm --resource flask-app-image=./image_metadata.json library-charm
-          juju refresh library-charm --path=./library-charm_amd64.charm --resource flask-app-image=./image_metadata.json
+          juju deploy ./library-charm_amd64.charm --resource flask-app-image=./image_metadata.json library-charm
+          # juju refresh library-charm --path=./library-charm_amd64.charm --resource flask-app-image=./image_metadata.json


### PR DESCRIPTION
## Done

I am trying to fix the 503 error we are getting on the deployment of the charm to library.staging.canonical.com by:
- Updating deploy.yaml to deploy fresh to new model
- Also created a new model on the PS6 stack and will be deploying there 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8051/
- Please Check the following basic functionalities work correctly:
    - Library displays docs correctly
    - Library search works correctly and display list of results
    - Library displays code correctly -> Check /about-the-library/tests-and-issues-(for-development-purpose)/code-formatting
    - Library displays list and tables correctly ->/about-the-library/tests-and-issues-(for-development-purpose)/table-and-list-examples
    - Library soft roots work correctly


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
