### PR TITLE
fix redirect after login

### DIFF
--- a/webapp/sso.py
+++ b/webapp/sso.py
@@ -1,4 +1,5 @@
 import os
+from urllib.parse import quote_plus
 import flask
 import socket
 from django_openid_auth.teams import TeamsRequest, TeamsResponse
@@ -62,7 +63,9 @@ def init_sso(app):
         ) or flask.request.path.startswith("/static"):
             return
         if "openid" not in flask.session:
-            return flask.redirect("/login?next=" + flask.request.path)
+            return flask.redirect(
+                "/login?next=" + quote_plus(flask.request.path)
+            )
 
     @app.after_request
     def add_headers(response):


### PR DESCRIPTION
## Done

- Fix login redirect URL to encode next route

## QA
- Open a private window
- Go to https://library-canonical-com-155.demos.haus/information-services-&-resources/using-our-vpn
- See that after you login, you're redirected to the correct path.
- Compare with current behavior https://library.canonical.com/information-services-&-resources/using-our-vpn


