### PR TITLE
fix publish.yaml

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,5 +11,6 @@ jobs:
     permissions:
       contents: write
     with:
-      resource-mapping: '{"library-rock": "app-image"}'
+      resource-mapping: '{"library-rock": "flask-app-image"}'
+      integration-test-workflow-file: integration-test.yaml
     secrets: inherit


### PR DESCRIPTION
## Done

fix publish.yaml

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8051/
- If the test folder is not displayed go to .env file and change HIDE_FOLDER to false: `HIDE_FOLDER=false`
- Please check the following basic functionalities work correctly:
    - Library displays docs correctly
    - Library search works correctly and displays a list of results
    - Library displays code correctly -> Check /about-the-library/tests-and-issues-(for-development-purpose)/code-formatting
    - Library displays list and tables correctly -> Check /about-the-library/tests-and-issues-(for-development-purpose)/table-and-list-examples
    - Library soft roots work correctly 

Soft roots are when a folder is selected and the side navigation hides all but the current selected folder and its children. An example of this is the Documentation folder on the Library side navigation.


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
